### PR TITLE
Update cms_plugins.py for Django 4 compatibility

### DIFF
--- a/djangocms_tacc_image_gallery/cms_plugins.py
+++ b/djangocms_tacc_image_gallery/cms_plugins.py
@@ -1,7 +1,7 @@
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 @plugin_pool.register_plugin
 class TaccsiteImageGalleryPlugin(CMSPluginBase):


### PR DESCRIPTION
Django 4 renames `ugettext` to `gettext` and deprecates the old name.